### PR TITLE
[UI]天気予報画面の更新

### DIFF
--- a/WeatherApp.xcodeproj/project.pbxproj
+++ b/WeatherApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		66C59C862DC118AE00A68E32 /* ForecastRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C59C852DC118AE00A68E32 /* ForecastRow.swift */; };
 		66CC7ADE2DBF46BA00D398EF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 66CC7ADA2DBF46BA00D398EF /* Assets.xcassets */; };
 		66CC7ADF2DBF46BA00D398EF /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CC7ADB2DBF46BA00D398EF /* HomeView.swift */; };
 		66CC7AE02DBF46BA00D398EF /* WeatherApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CC7ADC2DBF46BA00D398EF /* WeatherApp.swift */; };
@@ -47,6 +48,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		66C59C852DC118AE00A68E32 /* ForecastRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastRow.swift; sourceTree = "<group>"; };
 		66CC7A582DBE696000D398EF /* WeatherApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeatherApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		66CC7A652DBE696200D398EF /* WeatherAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WeatherAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		66CC7A6F2DBE696200D398EF /* WeatherAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WeatherAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -232,6 +234,7 @@
 			isa = PBXGroup;
 			children = (
 				66CC7B402DBFCCD800D398EF /* ImageView.swift */,
+				66C59C852DC118AE00A68E32 /* ForecastRow.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -397,6 +400,7 @@
 				66CC7B092DBFB43500D398EF /* ForecastRepository.swift in Sources */,
 				66CC7B0C2DBFB99400D398EF /* WeatherForecast.swift in Sources */,
 				66CC7B032DBF7AE000D398EF /* WeatherView.swift in Sources */,
+				66C59C862DC118AE00A68E32 /* ForecastRow.swift in Sources */,
 				66CC7AE02DBF46BA00D398EF /* WeatherApp.swift in Sources */,
 				66CC7AF92DBF62BE00D398EF /* RequestProtocol.swift in Sources */,
 				66CC7AF72DBF624A00D398EF /* APIError.swift in Sources */,

--- a/WeatherApp.xcodeproj/project.pbxproj
+++ b/WeatherApp.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		66CC7B092DBFB43500D398EF /* ForecastRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CC7B082DBFB43500D398EF /* ForecastRepository.swift */; };
 		66CC7B0C2DBFB99400D398EF /* WeatherForecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CC7B0B2DBFB99400D398EF /* WeatherForecast.swift */; };
 		66CC7B3E2DBFC6CB00D398EF /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CC7B3D2DBFC6CB00D398EF /* Int+Extensions.swift */; };
+		66CC7B412DBFCCD800D398EF /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CC7B402DBFCCD800D398EF /* ImageView.swift */; };
+		66CC7B452DC10CD100D398EF /* CachedAsyncImage in Frameworks */ = {isa = PBXBuildFile; productRef = 66CC7B442DC10CD100D398EF /* CachedAsyncImage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +71,7 @@
 		66CC7B082DBFB43500D398EF /* ForecastRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastRepository.swift; sourceTree = "<group>"; };
 		66CC7B0B2DBFB99400D398EF /* WeatherForecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherForecast.swift; sourceTree = "<group>"; };
 		66CC7B3D2DBFC6CB00D398EF /* Int+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extensions.swift"; sourceTree = "<group>"; };
+		66CC7B402DBFCCD800D398EF /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +79,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				66CC7B452DC10CD100D398EF /* CachedAsyncImage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -104,6 +108,7 @@
 				66CC7ADD2DBF46BA00D398EF /* WeatherApp */,
 				66CC7AE22DBF46C000D398EF /* WeatherAppTests */,
 				66CC7AE62DBF46C500D398EF /* WeatherAppUITests */,
+				66CC7B432DC10CD100D398EF /* Frameworks */,
 				66CC7A592DBE696000D398EF /* Products */,
 			);
 			sourceTree = "<group>";
@@ -151,6 +156,7 @@
 		66CC7AE92DBF46DB00D398EF /* View */ = {
 			isa = PBXGroup;
 			children = (
+				66CC7B3F2DBFCCAD00D398EF /* Component */,
 				66CC7ADB2DBF46BA00D398EF /* HomeView.swift */,
 				66CC7B022DBF7AE000D398EF /* WeatherView.swift */,
 			);
@@ -222,6 +228,21 @@
 			path = Utility;
 			sourceTree = "<group>";
 		};
+		66CC7B3F2DBFCCAD00D398EF /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				66CC7B402DBFCCD800D398EF /* ImageView.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
+		66CC7B432DC10CD100D398EF /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -240,6 +261,7 @@
 			);
 			name = WeatherApp;
 			packageProductDependencies = (
+				66CC7B442DC10CD100D398EF /* CachedAsyncImage */,
 			);
 			productName = WeatherApp;
 			productReference = 66CC7A582DBE696000D398EF /* WeatherApp.app */;
@@ -320,6 +342,7 @@
 			packageReferences = (
 				66CC7AA62DBE7A9500D398EF /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 				66CC7AC12DBE83DF00D398EF /* XCRemoteSwiftPackageReference "SwiftFormat" */,
+				66CC7B422DBFD4ED00D398EF /* XCRemoteSwiftPackageReference "CachedAsyncImage" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 66CC7A592DBE696000D398EF /* Products */;
@@ -363,6 +386,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				66CC7B412DBFCCD800D398EF /* ImageView.swift in Sources */,
 				66CC7AEC2DBF483C00D398EF /* Region.swift in Sources */,
 				66CC7B012DBF6F3200D398EF /* GetWeatherForecastResponse.swift in Sources */,
 				66CC7B3E2DBFC6CB00D398EF /* Int+Extensions.swift in Sources */,
@@ -722,6 +746,14 @@
 				minimumVersion = 0.55.5;
 			};
 		};
+		66CC7B422DBFD4ED00D398EF /* XCRemoteSwiftPackageReference "CachedAsyncImage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/jakirseu/CachedAsyncImage";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -729,6 +761,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 66CC7AA62DBE7A9500D398EF /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
+		66CC7B442DC10CD100D398EF /* CachedAsyncImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 66CC7B422DBFD4ED00D398EF /* XCRemoteSwiftPackageReference "CachedAsyncImage" */;
+			productName = CachedAsyncImage;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WeatherApp.xcodeproj/project.pbxproj
+++ b/WeatherApp.xcodeproj/project.pbxproj
@@ -541,6 +541,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -569,6 +570,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/WeatherApp.xcodeproj/project.pbxproj
+++ b/WeatherApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		66CC7B072DBFAF5D00D398EF /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CC7B062DBFAF5D00D398EF /* Repository.swift */; };
 		66CC7B092DBFB43500D398EF /* ForecastRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CC7B082DBFB43500D398EF /* ForecastRepository.swift */; };
 		66CC7B0C2DBFB99400D398EF /* WeatherForecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CC7B0B2DBFB99400D398EF /* WeatherForecast.swift */; };
+		66CC7B3E2DBFC6CB00D398EF /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CC7B3D2DBFC6CB00D398EF /* Int+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +68,7 @@
 		66CC7B062DBFAF5D00D398EF /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 		66CC7B082DBFB43500D398EF /* ForecastRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastRepository.swift; sourceTree = "<group>"; };
 		66CC7B0B2DBFB99400D398EF /* WeatherForecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherForecast.swift; sourceTree = "<group>"; };
+		66CC7B3D2DBFC6CB00D398EF /* Int+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -196,6 +198,7 @@
 		66CC7B042DBFAF2C00D398EF /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				66CC7B3C2DBFC6B600D398EF /* Utility */,
 				66CC7B052DBFAF4100D398EF /* Repository */,
 				66CC7AEA2DBF480200D398EF /* Model */,
 			);
@@ -209,6 +212,14 @@
 				66CC7B082DBFB43500D398EF /* ForecastRepository.swift */,
 			);
 			path = Repository;
+			sourceTree = "<group>";
+		};
+		66CC7B3C2DBFC6B600D398EF /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				66CC7B3D2DBFC6CB00D398EF /* Int+Extensions.swift */,
+			);
+			path = Utility;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -354,6 +365,7 @@
 			files = (
 				66CC7AEC2DBF483C00D398EF /* Region.swift in Sources */,
 				66CC7B012DBF6F3200D398EF /* GetWeatherForecastResponse.swift in Sources */,
+				66CC7B3E2DBFC6CB00D398EF /* Int+Extensions.swift in Sources */,
 				66CC7ADF2DBF46BA00D398EF /* HomeView.swift in Sources */,
 				66CC7AFB2DBF650100D398EF /* HTTPMethod.swift in Sources */,
 				66CC7AFE2DBF664E00D398EF /* GetWeatherForecastRequest.swift in Sources */,

--- a/WeatherApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WeatherApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "ba2873a17e5f04d756383228996bbd065c79c25f2c075b5996400bc16a76698e",
+  "originHash" : "4d7bc5501b02eac1597e2a0a77a2fd1a10deb7069666b64112965e63455fea1b",
   "pins" : [
+    {
+      "identity" : "cachedasyncimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jakirseu/CachedAsyncImage",
+      "state" : {
+        "revision" : "77b32450fdb8eaa868cbc13eb6bbc81ea7b46cd0",
+        "version" : "1.0.2"
+      }
+    },
     {
       "identity" : "swiftformat",
       "kind" : "remoteSourceControl",

--- a/WeatherApp/Data/APIClient.swift
+++ b/WeatherApp/Data/APIClient.swift
@@ -23,8 +23,15 @@ struct APIClient {
 
         // キャッシュは同日のみ有効にする
         if let cache = URLCache.shared.cachedResponse(for: urlRequest) {
+            // 現在の日付を日本時間で取得
+            let currentDate = Date()
+            let japanTimeZone = TimeZone(identifier: "Asia/Tokyo")!
+            var calendar = Calendar.current
+            calendar.timeZone = japanTimeZone
+
+            // キャッシュの取得日を取得
             if let cachedDate = cache.userInfo?["date"] as? Date {
-                let calendar = Calendar.current
+                // 日本時間で同じ日かどうかをチェック
                 if calendar.isDate(currentDate, inSameDayAs: cachedDate) {
                     decode(data: cache.data, completion: completion)
                     return

--- a/WeatherApp/Domain/Model/WeatherForecast.swift
+++ b/WeatherApp/Domain/Model/WeatherForecast.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct WeatherForecast: Codable, Hashable {
-    let dt: Int
+    let date: String
     let temp: Double
     let weather: [Weather]
 

--- a/WeatherApp/Domain/Model/WeatherForecast.swift
+++ b/WeatherApp/Domain/Model/WeatherForecast.swift
@@ -3,9 +3,5 @@ import Foundation
 struct WeatherForecast: Codable, Hashable {
     let date: String
     let temp: Double
-    let weather: [Weather]
-
-    struct Weather: Codable, Hashable {
-        let icon: String
-    }
+    let iconUrl: String
 }

--- a/WeatherApp/Domain/Repository/ForecastRepository.swift
+++ b/WeatherApp/Domain/Repository/ForecastRepository.swift
@@ -22,10 +22,15 @@ struct ForecastRepository: Repository {
             WeatherForecast(
                 date: $0.dt.convertToJstDateString(),
                 temp: $0.main.temp,
-                weather: $0.weather.map {
-                    .init(icon: $0.icon)
-                }
+                iconUrl: convertToIconUrlString(iconId: $0.weather.first?.icon)
             )
         }
+    }
+
+    private static func convertToIconUrlString(iconId: String?) -> String {
+        guard let iconId else {
+            return ""
+        }
+        return "https://openweathermap.org/img/wn/\(iconId)@2x.png"
     }
 }

--- a/WeatherApp/Domain/Repository/ForecastRepository.swift
+++ b/WeatherApp/Domain/Repository/ForecastRepository.swift
@@ -20,9 +20,11 @@ struct ForecastRepository: Repository {
     ) -> [WeatherForecast] {
         return response.list.map {
             WeatherForecast(
-                dt: $0.dt,
+                date: $0.dt.convertToJstDateString(),
                 temp: $0.main.temp,
-                weather: []
+                weather: $0.weather.map {
+                    .init(icon: $0.icon)
+                }
             )
         }
     }

--- a/WeatherApp/Domain/Utility/Int+Extensions.swift
+++ b/WeatherApp/Domain/Utility/Int+Extensions.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension Int {
+    func convertToJstDateString() -> String {
+        // UNIXタイムスタンプをDate型に変換
+        let date = Date(timeIntervalSince1970: TimeInterval(self))
+
+        // 日本時間のタイムゾーンを設定
+        let formatter = DateFormatter()
+        formatter.timeZone = TimeZone(identifier: "Asia/Tokyo")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+        let jstDateString = formatter.string(from: date)
+        return jstDateString
+    }
+}

--- a/WeatherApp/View/Component/ForecastRow.swift
+++ b/WeatherApp/View/Component/ForecastRow.swift
@@ -10,7 +10,8 @@ struct ForecastRow: View {
                 .padding(.trailing, 16)
 
             VStack(alignment: .leading) {
-                Text("\(forecast.temp)°C")
+                // 小数点第1位まで表示する
+                Text("\(String(format: "%.1f", forecast.temp))°C")
                     .font(.headline)
                 Text("\(forecast.date)")
                     .font(.subheadline)
@@ -23,7 +24,7 @@ struct ForecastRow: View {
 #Preview {
     ForecastRow(
         forecast: .init(
-            date: "2025",
+            date: "2025-04-28 18:00:00",
             temp: 19.28,
             iconUrl: "https://openweathermap.org/img/wn/10d@2x.png"
         )

--- a/WeatherApp/View/Component/ForecastRow.swift
+++ b/WeatherApp/View/Component/ForecastRow.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct ForecastRow: View {
+    var forecast: WeatherForecast
+
+    var body: some View {
+        HStack {
+            ImageView(imageUrl: forecast.iconUrl)
+                .frame(width: 40, height: 40)
+                .padding(.trailing, 16)
+
+            VStack(alignment: .leading) {
+                Text("\(forecast.temp)°C")
+                    .font(.headline)
+                Text("\(forecast.date)")
+                    .font(.subheadline)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    ForecastRow(
+        forecast: .init(
+            date: "2025",
+            temp: 19.28,
+            iconUrl: "https://openweathermap.org/img/wn/10d@2x.png"
+        )
+    )
+}

--- a/WeatherApp/View/Component/ImageView.swift
+++ b/WeatherApp/View/Component/ImageView.swift
@@ -1,0 +1,14 @@
+import CachedAsyncImage
+import SwiftUI
+
+struct ImageView: View {
+    let imageUrl: String
+
+    var body: some View {
+        CachedAsyncImage(url: URL(string: imageUrl))
+    }
+}
+
+#Preview {
+    ImageView(imageUrl: "https://openweathermap.org/img/wn/10d@2x.png")
+}

--- a/WeatherApp/View/Component/ImageView.swift
+++ b/WeatherApp/View/Component/ImageView.swift
@@ -10,5 +10,7 @@ struct ImageView: View {
 }
 
 #Preview {
-    ImageView(imageUrl: "https://openweathermap.org/img/wn/10d@2x.png")
+    ImageView(
+        imageUrl: "https://openweathermap.org/img/wn/10d@2x.png"
+    )
 }

--- a/WeatherApp/View/WeatherView.swift
+++ b/WeatherApp/View/WeatherView.swift
@@ -34,12 +34,18 @@ struct WeatherView: View {
         VStack {
             List(forecasts, id: \.date) { forecast in
                 HStack {
-                    Image(systemName: "cloud")
+                    ImageView(imageUrl: forecast.iconUrl)
+                        .frame(width: 40, height: 40)
+                        .padding(.trailing, 16)
+
                     VStack(alignment: .leading) {
                         Text("\(forecast.temp)°C")
+                            .font(.headline)
                         Text("\(forecast.date)")
+                            .font(.subheadline)
                     }
                 }
+                .padding(.vertical, 4)
             }
         }
         .padding()

--- a/WeatherApp/View/WeatherView.swift
+++ b/WeatherApp/View/WeatherView.swift
@@ -32,7 +32,6 @@ struct WeatherView: View {
 
     var body: some View {
         forecastListView
-            .padding()
             .task {
                 await getWeather() // Viewがロードされたときに天気情報を取得
             }

--- a/WeatherApp/View/WeatherView.swift
+++ b/WeatherApp/View/WeatherView.swift
@@ -31,42 +31,36 @@ struct WeatherView: View {
     }
 
     var body: some View {
-        VStack {
-            List(forecasts, id: \.date) { forecast in
-                HStack {
-                    ImageView(imageUrl: forecast.iconUrl)
-                        .frame(width: 40, height: 40)
-                        .padding(.trailing, 16)
-
-                    VStack(alignment: .leading) {
-                        Text("\(forecast.temp)°C")
-                            .font(.headline)
-                        Text("\(forecast.date)")
-                            .font(.subheadline)
-                    }
-                }
-                .padding(.vertical, 4)
+        forecastListView
+            .padding()
+            .task {
+                await getWeather() // Viewがロードされたときに天気情報を取得
             }
+            .navigationTitle(region.name)
+            .alert(isPresented: $showAlert) {
+                errorAlert
+            }
+    }
+
+    private var forecastListView: some View {
+        List(forecasts, id: \.date) { forecast in
+            ForecastRow(forecast: forecast)
         }
-        .padding()
-        .task {
-            await getWeather() // Viewがロードされたときに天気情報を取得
-        }
-        .navigationTitle(region.name)
-        .alert(isPresented: $showAlert) {
-            Alert(
-                title: Text("エラー"),
-                message: Text(errorMessage ?? "不明なエラーが発生しました。"),
-                primaryButton: .default(Text("リトライ")) {
-                    Task {
-                        await getWeather()
-                    }
-                },
-                secondaryButton: .cancel(Text("戻る")) {
-                    presentationMode.wrappedValue.dismiss()
+    }
+
+    private var errorAlert: Alert {
+        Alert(
+            title: Text("エラー"),
+            message: Text(errorMessage ?? "不明なエラーが発生しました。"),
+            primaryButton: .default(Text("リトライ")) {
+                Task {
+                    await getWeather()
                 }
-            )
-        }
+            },
+            secondaryButton: .cancel(Text("戻る")) {
+                presentationMode.wrappedValue.dismiss()
+            }
+        )
     }
 }
 

--- a/WeatherApp/View/WeatherView.swift
+++ b/WeatherApp/View/WeatherView.swift
@@ -32,12 +32,12 @@ struct WeatherView: View {
 
     var body: some View {
         VStack {
-            List(forecasts, id: \.dt) { forecast in
+            List(forecasts, id: \.date) { forecast in
                 HStack {
                     Image(systemName: "cloud")
                     VStack(alignment: .leading) {
                         Text("\(forecast.temp)°C")
-                        Text("\(forecast.dt)")
+                        Text("\(forecast.date)")
                     }
                 }
             }


### PR DESCRIPTION
### 実装機能
- iOSの下限OSを16に設定
- 日付を日本時間で表示
- 気温を小数点第一位まで表示
- APIで取得したアイコンIDを仕様して画像を表示
- APIリクエストで同日のキャッシュを有効にする

### スクリーンショット

<image src="https://github.com/user-attachments/assets/d8055aae-89a3-4f00-b55e-94123cecc5c0" width="300">

### 使用ライブラリ
- 画像のロード、キャッシュ管理
https://github.com/jakirseu/CachedAsyncImage